### PR TITLE
Update license.md

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,13 +1,9 @@
-# Licenses
+# Specification License
 
-## Specification License
+Specifications in this repository are subject to the W3C Patent Policy (2004), available at http://www.w3.org/Consortium/Patent-Policy-20040205.
 
-Specifications in the repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+# Source Code License
 
-## Source Code License
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the Apache 2.0 license, available at http://www.apache.org/licenses/LICENSE-2.0.html, unless otherwise designated. In the case of any conflict or confusion within this specification repository between the W3C Patent Policy (2004) or other designated license, the terms of the W3C Patent Policy (2004) shall apply.
 
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise designated. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated license, the terms of the Community Specification License shall apply.
-
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
-
-In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.
+These terms are inherited from the Decentralized Identity Foundation Project Charter, available at https://github.com/decentralized-identity/org/blob/main/Org%20documents/Membership%20agreements/DIF%20Project%20Charter%20_4.0.3.pdf


### PR DESCRIPTION
Insert DIF's standard license. Since there will be no source code deliverable, it's ok to omit the "Source Code License" part and say source code is out of scope, as in the Charter Scope